### PR TITLE
Add output field that describes if a requirement is normative or not

### DIFF
--- a/rtm_doorstop.py
+++ b/rtm_doorstop.py
@@ -24,6 +24,7 @@ def rtm_builder(
         {
             "UID": str(item),
             "Has Test": bool(item.child_links),
+            "Need Test": bool(item.normative),
             "Tests": " ".join([str(child) for child in item.child_links]),
         }
         for item in reqs_doc.items
@@ -36,7 +37,7 @@ def rtm_builder(
 
     if csv_path:
         with open(csv_path, "w", newline="") as csvfile:
-            fieldnames = ["UID", "Has Test", "Tests"]
+            fieldnames = ["UID", "Has Test", "Need Test", "Tests"]
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
             for row in table_data:

--- a/tests/reqs/req/REQ0002.yml
+++ b/tests/reqs/req/REQ0002.yml
@@ -3,7 +3,7 @@ derived: false
 header: ''
 level: 1.1
 links: []
-normative: true
+normative: false
 ref: ''
 reviewed: q2wICIho_hVPcE3xOanrM1-dMq2911sbZIzZHOeMnl4=
 text: ''

--- a/tests/reqs/test_rtm_doorstop.py
+++ b/tests/reqs/test_rtm_doorstop.py
@@ -44,7 +44,12 @@ def test_csv_writer(tmpdir):
         reader = csv.DictReader(csvfile)
         csvcontents = [row for row in reader]
     assert csvcontents == [
-        {"UID": "REQ0001", "Has Test": "True", "Tests": "TST0001"},
-        {"UID": "REQ0002", "Has Test": "False", "Tests": ""},
-        {"UID": "REQ0003", "Has Test": "True", "Tests": "TST0003 TST0004 TST0005"},
+        {"UID": "REQ0001", "Has Test": "True", "Need Test": "True", "Tests": "TST0001"},
+        {"UID": "REQ0002", "Has Test": "False", "Need Test": "False", "Tests": ""},
+        {
+            "UID": "REQ0003",
+            "Has Test": "True",
+            "Need Test": "True",
+            "Tests": "TST0003 TST0004 TST0005",
+        },
     ]


### PR DESCRIPTION
Non-normative requirements may not needs to be satisfied. By adding a field that describes whether a requirement is normative or not, it is possible to quickly distinguish between an untested requirement that needs to be addressed and an untested requirement that is acceptable as-is.